### PR TITLE
add full path for source video and source bash with cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Adjust your configuration in the `slowmovie-config.yml` file.
 
 ```yaml
 movie:
-  video_file: "input.mkv"
+  video_file: "/home/mike/compile/slowmovie/input.mkv"
   prefix: "frame"   # Optional
   frame_divisor: 5  # Optional
 
@@ -73,5 +73,5 @@ Run the frame publishing script every 4 minutes using the following crontab
 job:
 
 ```
-*/4 * * * * /home/mike/compile/slowmovie/slowmovie_framepublisher.py
+*/4 * * * * bash -lc /home/mike/compile/slowmovie/slowmovie_framepublisher.py
 ```

--- a/slowmovie-config.yml
+++ b/slowmovie-config.yml
@@ -1,5 +1,5 @@
 movie:
-  video_file: "input.mkv"
+  video_file: "/home/mike/compile/slowmovie/input.mkv"
 
 mqtt:
   addr: "192.168.1.135"


### PR DESCRIPTION
- Show full path to source video in yaml
- Ensure the cron job has access to the user path, as ffprobe was not found in the path