### PR TITLE
Fix FPS fetching and package deletion

### DIFF
--- a/slowmovie_framepublisher.py
+++ b/slowmovie_framepublisher.py
@@ -21,6 +21,7 @@ import os
 import yaml
 import anyio
 import semver
+import sys
 from pathlib import Path
 from golioth import Client
 
@@ -44,9 +45,15 @@ class SourceVideo:
         return int(result.stdout)
 
     def get_fps(self, video_file: str) -> float:
-        cmd = f'ffprobe {video_file} 2>&1| grep ",* fps" | cut -d "," -f 5 | cut -d " " -f 2'
+        cmd = f'ffprobe {video_file} 2>&1| grep ",* fps"'
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, check=True, shell=True)
-        return float(result.stdout)
+
+        for i in result.stdout.split(','):
+            if ' fps' == i[-4:]:
+                return float(i.strip().split(' ')[0])
+
+        print(f"Error, fps not found in: {result.stdout}")
+        sys.exit(-1)
 
     def harvest_frame(self, frame_count: int, video_in: str | None = None, frame_out: str | None = None, framerate: int | None = None) -> bool:
         v_in = video_in or self.video_file

--- a/slowmovie_framepublisher.py
+++ b/slowmovie_framepublisher.py
@@ -152,11 +152,16 @@ class SlowMovie:
         try:
             art = await p.artifacts.upload(Path('frame-800x480.pbm'), str(next_ver), 'frame')
             await p.settings.set("FRAME", f"/.u/c/frame@{str(next_ver)}")
-            for a in artifacts:
-                if a != art:
-                    await p.artifacts.delete(a.id)
         except Exception as e:
             print(f"Failed to upload frame: {str(e)}")
+            return
+
+        try:
+            for a in artifacts:
+                if a.package == 'frame' and a != art:
+                    await p.artifacts.delete(a.id)
+        except Exception as e:
+            print(f"Failed to delete frame: {str(e)}")
             return
 
         #Increment framecount and save


### PR DESCRIPTION
This PR improves how FPS is collected, but this approach is still rather brittle and could use more work.

After implementing OTA firmware updates, the deletion of old frames cause the frame publisher to hang because it was trying to delete all packages, not just old frames, and that includes the firmware currently rolled out to devices. Now this will only delete older `frame` packages.